### PR TITLE
Bug/newrelic does not differenciate method calls

### DIFF
--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -10,7 +10,7 @@ from savory_pie.context import APIContext
 from savory_pie.django import validators
 from savory_pie.errors import AuthorizationError, PreConditionError, MethodNotAllowedError
 from savory_pie.formatters import JSONFormatter
-from savory_pie.newrelic import set_transaction_name
+from savory_pie.savory_newrelic import set_transaction_name
 from savory_pie.helpers import get_sha1, process_get_request, process_post_request, process_put_request, process_delete_request
 
 logger = logging.getLogger(__name__)

--- a/savory_pie/savory_newrelic.py
+++ b/savory_pie/savory_newrelic.py
@@ -5,7 +5,7 @@ try:
     import newrelic.agent as agent
 
     def set_transaction_name(func):
-        @functools.wraps
+        @functools.wraps(func)
         def inner(request, resource_path):
             agent.set_transaction_name(
                 resource_path,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = '0.1.5'
+version = '0.1.6'
 
 setup(
     name='savory-pie',


### PR DESCRIPTION
Fixed an issue where the "newrelic.py" was being imported instead of
the real newrelic module.  Also, fixed it so that functool.wraps was
not used properly.