### PR TITLE
Updates to API

### DIFF
--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -17,6 +17,7 @@ from savory_pie.utils import deprecated
 
 logger = logging.getLogger(__name__)
 
+
 @deprecated
 def batch_api_view(root_resource, base_regex):
     """

--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -403,6 +403,7 @@ def _validation_errors(ctx, resource, request, errors):
 def _created(ctx, resource, request, new_resource):
     response = HttpResponse(status=201)
     response['Location'] = ctx.build_resource_uri(new_resource)
+    ctx.formatter.write_to(new_resource, response)
     return response
 
 

--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -8,7 +8,7 @@ from django.utils.datastructures import MultiValueDict
 
 from savory_pie.context import APIContext
 from savory_pie.django import validators
-from savory_pie.errors import AuthorizationError, PreConditionError, MethodNotAllowedError
+from savory_pie.errors import AuthorizationError, PreConditionError, MethodNotAllowedError, ApiException
 from savory_pie.formatters import JSONFormatter
 from savory_pie.savory_newrelic import set_transaction_name
 from savory_pie.helpers import get_sha1, process_get_request, process_post_request, process_put_request, process_delete_request
@@ -172,10 +172,9 @@ def batch_api_view(root_resource, base_regex):
 
             return _content_success(ctx, None, request, {'data': result})
 
-        except Exception:
-            import traceback
-            logger.exception('Caught Exception in API')
-            return _internal_error(ctx, request, traceback.format_exc())
+        except Exception as e:
+            logger.exception('Caught Exception in API', e)
+            return _internal_error(ctx, request, ApiException(e.message))
 
     return view
 
@@ -234,10 +233,12 @@ def api_view(root_resource):
                 return _not_allowed_method(ctx, resource, request)
         except AuthorizationError as e:
             return _access_denied(ctx, field_name=e.name)
-        except Exception:
-            import traceback
+        except ApiException as e:
+            logger.error('Caught general ApiException', e.message)
+            return _internal_error(ctx, request, e)
+        except Exception as e:
             logger.exception('Caught Exception in API')
-            return _internal_error(ctx, request, traceback.format_exc())
+            return _internal_error(ctx, request, ApiException(e.message))
 
     return view
 
@@ -435,8 +436,7 @@ def _success(ctx, resource, request, content_dict=None):
 
 def _internal_error(ctx, request, error):
     response = HttpResponse(status=500, content_type=ctx.formatter.content_type)
-    error_body = {ctx.formatter.convert_to_public_property('error'): error}
-    ctx.formatter.write_to(error_body, response)
+    ctx.formatter.write_to(error.as_json, response)
     return response
 
 

--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -13,9 +13,11 @@ from savory_pie.formatters import JSONFormatter
 from savory_pie.savory_newrelic import set_transaction_name
 from savory_pie.helpers import get_sha1, process_get_request, process_post_request, process_put_request, process_delete_request
 
+from savory_pie.utils import deprecated
+
 logger = logging.getLogger(__name__)
 
-
+@deprecated
 def batch_api_view(root_resource, base_regex):
     """
     View function factory that provides accessing to the resource tree

--- a/savory_pie/errors.py
+++ b/savory_pie/errors.py
@@ -1,5 +1,6 @@
 from exceptions import Exception
 
+
 class ApiException(Exception):
     #
     # General API exception
@@ -12,6 +13,7 @@ class ApiException(Exception):
     @property
     def as_json(self):
         return self.__dict__
+
 
 class AuthorizationError(Exception):
 

--- a/savory_pie/errors.py
+++ b/savory_pie/errors.py
@@ -8,7 +8,7 @@ class ApiException(Exception):
     def __init__(self, message=None, *args, **kwargs):
         self.__dict__.update(kwargs)
         if message:
-            setattr(self, 'message', message)
+            self.message = message
 
     @property
     def as_json(self):

--- a/savory_pie/errors.py
+++ b/savory_pie/errors.py
@@ -2,9 +2,9 @@ from exceptions import Exception
 
 
 class ApiException(Exception):
-    #
-    # General API exception
-    #
+    """
+    General API exception
+    """
     def __init__(self, message=None, *args, **kwargs):
         self.__dict__.update(kwargs)
         if message:

--- a/savory_pie/errors.py
+++ b/savory_pie/errors.py
@@ -1,5 +1,17 @@
 from exceptions import Exception
 
+class ApiException(Exception):
+    #
+    # General API exception
+    #
+    def __init__(self, message=None, *args, **kwargs):
+        self.__dict__.update(kwargs)
+        if message:
+            setattr(self, 'message', message)
+
+    @property
+    def as_json(self):
+        return self.__dict__
 
 class AuthorizationError(Exception):
 

--- a/savory_pie/resources.py
+++ b/savory_pie/resources.py
@@ -95,7 +95,7 @@ class BasicResource(dict):
     @property
     def resource_path(self):
         key = self.key
-        return self.path + '/' + key if key else self.path
+        return "{}/{}".format(self.path, key) if key else self.path
 
     def get_child_resource(self, ctx, param):
         return None

--- a/savory_pie/resources.py
+++ b/savory_pie/resources.py
@@ -21,13 +21,15 @@ class EmptyParams(object):
     def keys(self):
         return []
 
+
 rest_methods = ['GET', 'POST', 'PUT', 'DELETE']
+
 
 class BasicResource(dict):
     published_key = ('id', str)
     path = ''
 
-    def __init__(self, dict = None):
+    def __init__(self, dict=None):
         if dict:
             self.update(dict)
 
@@ -97,7 +99,7 @@ class BasicResource(dict):
     @property
     def resource_path(self):
         key = self.key
-        return self.path + '/' + self.key if self.key else self.path
+        return self.path + '/' + key if key else self.path
 
     def get_child_resource(self, ctx, param):
         return None

--- a/savory_pie/resources.py
+++ b/savory_pie/resources.py
@@ -29,10 +29,6 @@ class BasicResource(dict):
     published_key = ('id', str)
     path = ''
 
-    def __init__(self, dict=None):
-        if dict:
-            self.update(dict)
-
     def __getattr__(self, item):
         try:
             # Throws exception if not in prototype chain

--- a/savory_pie/resources.py
+++ b/savory_pie/resources.py
@@ -31,37 +31,21 @@ class BasicResource(dict):
 
     def __getattr__(self, item):
         try:
-            # Throws exception if not in prototype chain
-            return object.__getattribute__(self, item)
-        except AttributeError:
-            try:
-                return self[item]
-            except KeyError:
-                raise AttributeError(item)
+            return self[item]
+        except KeyError:
+            raise AttributeError('Accessing undefined attribute {0}'.format(item))
 
     def __setattr__(self, key, value):
         try:
-            # Throws exception if not in prototype chain
-            object.__getattribute__(self, key)
-        except AttributeError:
-            try:
-                self[key] = value
-            except:
-                raise AttributeError(key)
-        else:
-            object.__setattr__(self, key, value)
+            self[key] = value
+        except:
+            raise AttributeError('Unable to set attribute {0}'.format(key))
 
     def __delattr__(self, item):
         try:
-            # Throws exception if not in prototype chain
-            object.__getattribute__(self, item)
-        except AttributeError:
-            try:
-                del self[item]
-            except KeyError:
-                raise AttributeError(item)
-        else:
-            object.__delattr__(self, item)
+            del self[item]
+        except KeyError:
+            raise AttributeError('Unable to delete attribute {0}'.format(item))
 
     @property
     def key(self):

--- a/savory_pie/resources.py
+++ b/savory_pie/resources.py
@@ -36,10 +36,7 @@ class BasicResource(dict):
             raise AttributeError('Accessing undefined attribute {0}'.format(item))
 
     def __setattr__(self, key, value):
-        try:
-            self[key] = value
-        except:
-            raise AttributeError('Unable to set attribute {0}'.format(key))
+        self[key] = value
 
     def __delattr__(self, item):
         try:

--- a/savory_pie/tests/django/test_views.py
+++ b/savory_pie/tests/django/test_views.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 import mock
 from mock import Mock, patch
-from savory_pie.errors import AuthorizationError, PreConditionError
+from savory_pie.errors import AuthorizationError, PreConditionError, ApiException
 from savory_pie.formatters import JSONFormatter
 from savory_pie.resources import _ParamsImpl
 from savory_pie.helpers import get_sha1
@@ -547,6 +547,10 @@ class ViewTest(unittest.TestCase):
         self.assertEqual(response_json['validation_errors'], ['Modification of field foo not authorized'])
         self.assertEqual(response.status_code, 403)
 
+    # 
+    # GET methods
+    # 
+
     def test_get_success(self):
         root_resource = mock_resource(name='root')
         root_resource.allowed_methods.add('GET')
@@ -585,6 +589,38 @@ class ViewTest(unittest.TestCase):
 
         response = savory_dispatch(root_resource, method='GET')
         self.assertEqual(response.status_code, 405)
+
+    @mock.patch('savory_pie.django.views.logger')
+    def test_get_with_apiexception(self, logger):
+        root_resource = mock_resource(name='root')
+        root_resource.allowed_methods.add('GET')
+
+        root_resource.get = Mock(side_effect=ApiException('Some kind of server error'))
+
+        response = savory_dispatch(root_resource, method='GET')
+        self.assertEqual(response.status_code, 500)
+        content = json.loads(response.content)
+        self.assertTrue('message' in content)
+        self.assertEqual(content['message'], 'Some kind of server error')
+        self.assertTrue(logger.error.called)
+
+    @mock.patch('savory_pie.django.views.logger')
+    def test_get_with_exception(self, logger):
+        root_resource = mock_resource(name='root')
+        root_resource.allowed_methods.add('GET')
+
+        root_resource.get = Mock(side_effect=Exception('Some kind of server error'))
+
+        response = savory_dispatch(root_resource, method='GET')
+        self.assertEqual(response.status_code, 500)
+        content = json.loads(response.content)
+        self.assertTrue('message' in content)
+        self.assertEqual(content['message'], 'Some kind of server error')
+        self.assertTrue(logger.exception.called)
+
+    # 
+    # PUT methods
+    # 
 
     def test_put_no_content_success(self):
         root_resource = mock_resource(name='root')
@@ -633,6 +669,38 @@ class ViewTest(unittest.TestCase):
 
         response = savory_dispatch(root_resource, method='PUT', body='{}')
         self.assertEqual(response.status_code, 405)
+
+    @mock.patch('savory_pie.django.views.logger')
+    def test_put_with_apiexception(self, logger):
+        root_resource = mock_resource(name='root')
+        root_resource.allowed_methods.add('PUT')
+
+        root_resource.put = Mock(side_effect=ApiException('Some kind of server error'))
+
+        response = savory_dispatch(root_resource, method='PUT', body='{"foo": "bar"}')
+        self.assertEqual(response.status_code, 500)
+        content = json.loads(response.content)
+        self.assertTrue('message' in content)
+        self.assertEqual(content['message'], 'Some kind of server error')
+        self.assertTrue(logger.error.called)
+
+    @mock.patch('savory_pie.django.views.logger')
+    def test_put_with_exception(self, logger):
+        root_resource = mock_resource(name='root')
+        root_resource.allowed_methods.add('PUT')
+
+        root_resource.put = Mock(side_effect=Exception('Some kind of server error'))
+
+        response = savory_dispatch(root_resource, method='PUT', body='{"foo": "bar"}')
+        self.assertEqual(response.status_code, 500)
+        content = json.loads(response.content)
+        self.assertTrue('message' in content)
+        self.assertEqual(content['message'], 'Some kind of server error')
+        self.assertTrue(logger.exception.called)
+
+    # 
+    # POST methods
+    # 
 
     def test_post_success(self):
         root_resource = mock_resource(name='root')
@@ -704,10 +772,26 @@ class ViewTest(unittest.TestCase):
         response = savory_dispatch(root_resource, method='POST', body='{}')
         self.assertEqual(response.status_code, 500)
         content = json.loads(response.content)
-        self.assertTrue('error' in content)
-        self.assertTrue(content['error'].startswith('Traceback (most recent call last):'))
-        self.assertTrue('Some kind of server error' in content['error'])
+        self.assertTrue('message' in content)
+        self.assertEqual(content['message'], 'Some kind of server error')
         self.assertTrue(logger.exception.called)
+
+    @mock.patch('savory_pie.django.views.logger')
+    def test_post_with_apiexception(self, logger):
+        root_resource = mock_resource(name='root')
+        root_resource.allowed_methods.add('POST')
+
+        def side_effect(*args):
+            raise ApiException('Some kind of server error')
+
+        root_resource.post = Mock(side_effect=side_effect)
+
+        response = savory_dispatch(root_resource, method='POST', body='{}')
+        self.assertEqual(response.status_code, 500)
+        content = json.loads(response.content)
+        self.assertTrue('message' in content)
+        self.assertEqual(content['message'], 'Some kind of server error')
+        self.assertTrue(logger.error.called)
 
     def test_post_not_supported(self):
         root_resource = mock_resource(name='root')
@@ -715,6 +799,10 @@ class ViewTest(unittest.TestCase):
         response = savory_dispatch(root_resource, method='POST', body='{}')
 
         self.assertEqual(response.status_code, 405)
+
+    # 
+    # DELETE methods
+    # 
 
     def test_delete_success(self):
         root_resource = mock_resource(name='root')
@@ -765,16 +853,9 @@ class ViewTest(unittest.TestCase):
         response = savory_dispatch(root_resource, method='GET', resource_path='child/grandchild')
         self.assertEqual(response.status_code, 404)
 
-    def test_exception_handling(self):
-        root_resource = mock_resource(name='root')
-        root_resource.allowed_methods.add('GET')
-        root_resource.get.side_effect = Exception('Fail')
-
-        response = savory_dispatch(root_resource, method='GET')
-
-        response_json = json.loads(response.content)
-        self.assertIn('error', response_json)
-        self.assertEqual(response.status_code, 500)
+    # 
+    # Validation handling
+    # 
 
     def test_validation_handling(self):
         root_resource = mock_resource(name='root')
@@ -792,6 +873,10 @@ class ViewTest(unittest.TestCase):
         self.assertIn('validation_errors', response_json)
         self.assertEqual(response_json['validation_errors']['class.field'], 'broken')
         self.assertEqual(response.status_code, 400)
+
+    #
+    # Header methods
+    # 
 
     def test_set_header(self):
         """

--- a/savory_pie/tests/django/test_views.py
+++ b/savory_pie/tests/django/test_views.py
@@ -702,7 +702,9 @@ class ViewTest(unittest.TestCase):
     # POST methods
     # 
 
-    def test_post_success(self):
+    @mock.patch('savory_pie.django.views.JSONFormatter')
+    def test_post_success(self, formatter):
+        formatter.return_value = formatter
         root_resource = mock_resource(name='root')
         root_resource.allowed_methods.add('POST')
 
@@ -720,6 +722,9 @@ class ViewTest(unittest.TestCase):
             ]
         )
         self.assertEqual(response['Location'], 'http://localhost/api/foo')
+        self.assertTrue(formatter.write_to.called)
+        self.assertEqual(len(formatter.write_to.call_args), 2)
+        self.assertEqual(formatter.write_to.call_args[0][0], new_resource)
         self.assertIsNotNone(root_resource.post.call_args_list[0].request)
 
     def test_post_with_collision_one(self):

--- a/savory_pie/tests/django/test_views.py
+++ b/savory_pie/tests/django/test_views.py
@@ -547,9 +547,9 @@ class ViewTest(unittest.TestCase):
         self.assertEqual(response_json['validation_errors'], ['Modification of field foo not authorized'])
         self.assertEqual(response.status_code, 403)
 
-    # 
+    #
     # GET methods
-    # 
+    #
 
     def test_get_success(self):
         root_resource = mock_resource(name='root')
@@ -618,9 +618,9 @@ class ViewTest(unittest.TestCase):
         self.assertEqual(content['message'], 'Some kind of server error')
         self.assertTrue(logger.exception.called)
 
-    # 
+    #
     # PUT methods
-    # 
+    #
 
     def test_put_no_content_success(self):
         root_resource = mock_resource(name='root')
@@ -698,9 +698,9 @@ class ViewTest(unittest.TestCase):
         self.assertEqual(content['message'], 'Some kind of server error')
         self.assertTrue(logger.exception.called)
 
-    # 
+    #
     # POST methods
-    # 
+    #
 
     @mock.patch('savory_pie.django.views.JSONFormatter')
     def test_post_success(self, formatter):
@@ -805,9 +805,9 @@ class ViewTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 405)
 
-    # 
+    #
     # DELETE methods
-    # 
+    #
 
     def test_delete_success(self):
         root_resource = mock_resource(name='root')
@@ -858,9 +858,9 @@ class ViewTest(unittest.TestCase):
         response = savory_dispatch(root_resource, method='GET', resource_path='child/grandchild')
         self.assertEqual(response.status_code, 404)
 
-    # 
+    #
     # Validation handling
-    # 
+    #
 
     def test_validation_handling(self):
         root_resource = mock_resource(name='root')
@@ -881,7 +881,7 @@ class ViewTest(unittest.TestCase):
 
     #
     # Header methods
-    # 
+    #
 
     def test_set_header(self):
         """

--- a/savory_pie/tests/test_resource.py
+++ b/savory_pie/tests/test_resource.py
@@ -121,3 +121,20 @@ class BasicResourceTestCase(unittest.TestCase):
 
         self.assertEqual(resource.key, data['id'])
         self.assertEqual(resource.resource_path, 'test/' + data['id'])
+
+    def test_update(self):
+        resource = TestResource()
+
+        resource.field = 'string'
+
+        self.assertEqual(resource.field, 'string')
+        self.assertEqual(resource['field'], 'string')
+
+    def test_delete(self):
+        resource = TestResource({
+                'field': 123
+            })
+
+        del resource.field
+
+        self.assertNotIn('field', resource)

--- a/savory_pie/tests/test_resource.py
+++ b/savory_pie/tests/test_resource.py
@@ -1,6 +1,6 @@
 import unittest
 import mock
-from savory_pie.resources import _ParamsImpl, EmptyParams
+from savory_pie.resources import _ParamsImpl, EmptyParams, BasicResource
 
 
 class EmptyParamsTestCase(unittest.TestCase):
@@ -73,3 +73,50 @@ class ParamsImplTestCase(unittest.TestCase):
     def test_get_list_of_not_found(self):
         params = _ParamsImpl({'key1': [1]})
         self.assertEqual(params.get_list_of('key2', str), [])
+
+class TestResource(BasicResource):
+    path = 'test'
+
+    def get(self):
+        pass
+
+    def extra_method(self):
+        pass
+
+class BasicResourceTestCase(unittest.TestCase):
+
+    def test_init_empty(self):
+        resource = TestResource()
+        
+        self.assertEqual(resource.key, '')
+        self.assertEqual(resource.resource_path, 'test')
+        self.assertEqual(resource.allowed_methods, set(['GET']))
+
+    def test_init_with_dict(self):
+        data = {
+            'stringKey': 'stringValue',
+            'numberKey': 1,
+            'arrayKey': ['value1', 'value2', 'value3'],
+            'objectKey': {
+                'key': 'value'
+            }
+        }
+        resource = TestResource(data)
+
+        self.assertEqual(resource.stringKey, data['stringKey'])
+        self.assertEqual(resource.numberKey, data['numberKey'])
+        self.assertEqual(resource.arrayKey, data['arrayKey'])
+        self.assertEqual(resource.objectKey, data['objectKey'])
+        self.assertEqual(resource.key, '')
+        self.assertEqual(resource.resource_path, 'test')
+
+    def test_init_with_dict_and_id(self):
+        data = {
+            'id': '12335'
+        }
+
+        resource = TestResource(data)
+
+        self.assertEqual(resource.key, data['id'])
+        self.assertEqual(resource.resource_path, 'test/' + data['id'])
+

--- a/savory_pie/tests/test_resource.py
+++ b/savory_pie/tests/test_resource.py
@@ -74,6 +74,7 @@ class ParamsImplTestCase(unittest.TestCase):
         params = _ParamsImpl({'key1': [1]})
         self.assertEqual(params.get_list_of('key2', str), [])
 
+
 class TestResource(BasicResource):
     path = 'test'
 
@@ -83,11 +84,12 @@ class TestResource(BasicResource):
     def extra_method(self):
         pass
 
+
 class BasicResourceTestCase(unittest.TestCase):
 
     def test_init_empty(self):
         resource = TestResource()
-        
+
         self.assertEqual(resource.key, '')
         self.assertEqual(resource.resource_path, 'test')
         self.assertEqual(resource.allowed_methods, set(['GET']))
@@ -119,4 +121,3 @@ class BasicResourceTestCase(unittest.TestCase):
 
         self.assertEqual(resource.key, data['id'])
         self.assertEqual(resource.resource_path, 'test/' + data['id'])
-

--- a/savory_pie/tests/test_resource.py
+++ b/savory_pie/tests/test_resource.py
@@ -105,10 +105,7 @@ class BasicResourceTestCase(unittest.TestCase):
         }
         resource = TestResource(data)
 
-        self.assertEqual(resource.stringKey, data['stringKey'])
-        self.assertEqual(resource.numberKey, data['numberKey'])
-        self.assertEqual(resource.arrayKey, data['arrayKey'])
-        self.assertEqual(resource.objectKey, data['objectKey'])
+        self.assertDictEqual(data, resource)
         self.assertEqual(resource.key, '')
         self.assertEqual(resource.resource_path, 'test')
 

--- a/savory_pie/tests/test_resource.py
+++ b/savory_pie/tests/test_resource.py
@@ -129,8 +129,8 @@ class BasicResourceTestCase(unittest.TestCase):
 
     def test_delete(self):
         resource = TestResource({
-                'field': 123
-            })
+            'field': 123
+        })
 
         del resource.field
 

--- a/savory_pie/utils.py
+++ b/savory_pie/utils.py
@@ -1,13 +1,17 @@
 from datetime import datetime
 import warnings
 
+
 def deprecated(deprecated_func):
+
     message = deprecated_func.__name__ + ' is deprecated and is scheduled to be removed in the next major release of the library.'
+
     def temporary_func(*args, **kwargs):
         warnings.warn(message, DeprecationWarning)
         return deprecated_func(*args, **kwargs)
 
     return temporary_func
+
 
 def to_datetime(milliseconds):
     """

--- a/savory_pie/utils.py
+++ b/savory_pie/utils.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 import warnings
+import functools
 
 
 def deprecated(deprecated_func):
-
     message = deprecated_func.__name__ + ' is deprecated and is scheduled to be removed in the next major release of the library.'
 
+    @functools.wraps(deprecated_func)
     def temporary_func(*args, **kwargs):
         warnings.warn(message, DeprecationWarning)
         return deprecated_func(*args, **kwargs)

--- a/savory_pie/utils.py
+++ b/savory_pie/utils.py
@@ -4,7 +4,7 @@ import functools
 
 
 def deprecated(deprecated_func):
-    message = deprecated_func.__name__ + ' is deprecated and is scheduled to be removed in the next major release of the library.'
+    message = '{0} is deprecated and is scheduled to be removed in the next major release of the library.'.format(deprecated_func.__name__)
 
     @functools.wraps(deprecated_func)
     def temporary_func(*args, **kwargs):

--- a/savory_pie/utils.py
+++ b/savory_pie/utils.py
@@ -1,5 +1,13 @@
 from datetime import datetime
+import warnings
 
+def deprecated(deprecated_func):
+    message = deprecated_func.__name__ + ' is deprecated and is scheduled to be removed in the next major release of the library.'
+    def temporary_func(*args, **kwargs):
+        warnings.warn(message, DeprecationWarning)
+        return deprecated_func(*args, **kwargs)
+
+    return temporary_func
 
 def to_datetime(milliseconds):
     """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = '0.1.6'
+version = '0.1.7'
 
 setup(
     name='savory-pie',


### PR DESCRIPTION
# Better exception handling
* Adding `ApiException` that clients can throw with the data needed to be written in the response body
* Handling `ApiException` as handled error
* Keep general `Exception` handling, but wrapping the message into ApiException for proper response to the client

# Adding BasicResource
* `BasicResource` deals with API endpoints that are not reliant on Django ORM
* `BasicResource` wraps `dict` object and makes it behave as regular object
* Keeps the same interface as `Resource` object
* The goal is for `BasicResource` to become abstract `Resource` in the future. And `Resource` will become `DjangoResource`

# Response body for `POST` requests
* Using `JSONFormatter` to output the resource into the response body on `POST` requests.