### PR TITLE
Reducing noise in NewRelic reporting...

### DIFF
--- a/savory_pie/savory_newrelic.py
+++ b/savory_pie/savory_newrelic.py
@@ -1,5 +1,5 @@
 import functools
-
+import re
 
 try:
     import newrelic.agent as agent
@@ -8,7 +8,7 @@ try:
         @functools.wraps(func)
         def inner(request, resource_path):
             agent.set_transaction_name(
-                resource_path,
+                get_transaction_name_path(resource_path),
                 'Python/WebFramework/Controller'
             )
             return func(request, resource_path)
@@ -17,3 +17,20 @@ try:
 except ImportError:
     def set_transaction_name(func):
         return func
+
+
+def get_transaction_name_path(resource_path):
+    """
+    Takes a resource path and removes its last fragment if and only if that fragment is just digits
+    e.g.
+        'bars/foo' => 'bars/foo'
+        'bars/bar/9' => 'bars/bar'
+        'bars/19229' => 'bars'
+        'bars/magic8ball' => 'bars/magic8ball'
+    """
+    path_fragments = resource_path.split('/')
+
+    if re.match(r'^\d+$', path_fragments[-1]):
+        return '/'.join(path_fragments[:-1])
+    else:
+        return resource_path

--- a/savory_pie/tests/test_savory_newrelic.py
+++ b/savory_pie/tests/test_savory_newrelic.py
@@ -1,0 +1,38 @@
+import unittest
+
+from savory_pie.savory_newrelic import get_transaction_name_path
+
+
+class SavoryPieNewRelicTestCase(unittest.TestCase):
+
+    def _assertMakesInto(self, input, output):
+        self.assertEqual(get_transaction_name_path(input), output)
+
+    def _assertDoesNotChange(self, input):
+        self._assertMakesInto(input, input)
+
+    def test_does_not_modify_okay_paths(self):
+        self._assertDoesNotChange('bars/magic8ball')
+
+        self._assertDoesNotChange('merchandising')
+
+        self._assertDoesNotChange('merchandising/productcontext')
+
+        self._assertDoesNotChange('merchandising/productcontext/')
+
+        self._assertDoesNotChange('merchandising/productcontext/magic99')
+
+    def test_removes_final_id_from_resource_paths(self):
+        self._assertMakesInto('bars/foo', 'bars/foo')
+        self._assertMakesInto('bars/bar/9', 'bars/bar')
+        self._assertMakesInto('bars/19229', 'bars')
+
+        self._assertMakesInto(
+            'merchandising/productcontext/493949',
+            'merchandising/productcontext'
+        )
+
+        self._assertMakesInto(
+            'merchandising/productcontext/awesomeness/493949',
+            'merchandising/productcontext/awesomeness'
+        )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = '0.1.8'
+version = '0.1.9'
 
 setup(
     name='savory-pie',


### PR DESCRIPTION
...by stripping individual resource IDs from resource URIs for New Relic reporting

Currently SavoryPie logs every resource ID as its own request. This is a problem in systems that do mass-sequential GETs, DELETEs, and/or PUTs to resources because it causes NewRelic to be flooded with an excessive amount of data.

This PR changes the default behavior to strip off the trailing ID if there is one.


For example:
```
'bars/foo' => 'bars/foo'
'bars/bar/9' => 'bars/bar'
'bars/19229' => 'bars'
'bars/magic8ball' => 'bars/magic8ball'
```

This will allow NewRelic to see all PUTs to a given resource, for example, as the same action over and over again so that the data can be properly analyzed.