### PR TITLE
Replaced usages of @transaction.commit_manually with transaction.set_autocommit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # For testing django support
-Django<=1.6.6
+Django>=1.6.0,<1.9
 django_dirty_bits
 
 # Unit testing tools

--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -257,11 +257,12 @@ def _database_transaction_batch(func):
                 transaction.commit()
             else:
                 transaction.rollback()
-            transaction.set_autocommit(app_autocommit_flag)
         except:
             transaction.rollback()
-            transaction.set_autocommit(app_autocommit_flag)
             raise
+        finally:
+            transaction.set_autocommit(app_autocommit_flag)
+
         return response
 
     def outer(ctx, resource, request):
@@ -283,11 +284,12 @@ def _database_transaction(func):
                 transaction.commit()
             else:
                 transaction.rollback()
-            transaction.set_autocommit(app_autocommit_flag)
         except:
             transaction.rollback()
-            transaction.set_autocommit(app_autocommit_flag)
             raise
+        finally:
+            transaction.set_autocommit(app_autocommit_flag)
+
         return response
 
     def outer(ctx, resource, request):

--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -248,16 +248,19 @@ def _strip_query_string(path):
 
 def _database_transaction_batch(func):
     @functools.wraps(func)
-    @transaction.commit_manually
     def inner(ctx, resource, request, func=func):
+        app_autocommit_flag = transaction.get_autocommit()
+        transaction.set_autocommit(False)
         try:
             response = func(ctx, resource, request)
             if 200 <= response.get('status', 500) < 300:
                 transaction.commit()
             else:
                 transaction.rollback()
+            transaction.set_autocommit(app_autocommit_flag)
         except:
             transaction.rollback()
+            transaction.set_autocommit(app_autocommit_flag)
             raise
         return response
 
@@ -271,16 +274,19 @@ def _database_transaction_batch(func):
 
 def _database_transaction(func):
     @functools.wraps(func)
-    @transaction.commit_manually
     def inner(ctx, resource, request, func=func):
+        app_autocommit_flag = transaction.get_autocommit()
+        transaction.set_autocommit(False)
         try:
             response = func(ctx, resource, request)
             if 200 <= response.status_code < 300:
                 transaction.commit()
             else:
                 transaction.rollback()
+            transaction.set_autocommit(app_autocommit_flag)
         except:
             transaction.rollback()
+            transaction.set_autocommit(app_autocommit_flag)
             raise
         return response
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = '0.1.6.1'
+version = '0.1.6.2'
 
 setup(
     name='savory-pie',


### PR DESCRIPTION
`transaction.commit_manually` has been deprecated in django 1.6 and removed in django 1.8.  This update will use the replacement method `transaction.set_autocommit(true_or_false)

Code that needs transactions managed uses 1 of 2 decorators `_database_transaction` or `_database_transaction_batch`.  When these decorators are invoked, we retrieve the applications current autocommit setting and set autocommit to false.  After attempting to call the wrapped function we set autocmmit back to what it was before the decorator was invoked.