### PR TITLE
Fixing for django test case

### DIFF
--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import re
 
-from django.db import transaction
+from django.db import transaction, DatabaseError
 from django.http import HttpResponse, StreamingHttpResponse, HttpRequest
 from django.utils.datastructures import MultiValueDict
 
@@ -246,22 +246,28 @@ def _strip_query_string(path):
     return path.split('?', 1)[0]
 
 
+class _RequestError(DatabaseError):
+    """
+    An error that will get raised when an endpoint returns anything other than 200 level response code.
+    Since this is a subclass of `DatabaseError`, raising this error will cause the atomic block to rollback the changes.
+    """
+    pass
+
+
 def _database_transaction_batch(func):
     @functools.wraps(func)
     def inner(ctx, resource, request, func=func):
-        app_autocommit_flag = transaction.get_autocommit()
-        transaction.set_autocommit(False)
         try:
-            response = func(ctx, resource, request)
-            if 200 <= response.get('status', 500) < 300:
-                transaction.commit()
-            else:
-                transaction.rollback()
+            with transaction.atomic():
+                response = func(ctx, resource, request)
+                if not 200 <= response.get('status', 500) < 300:
+                    # force a rollback
+                    raise _RequestError
+        except _RequestError:
+            # Allow the response to be returned.
+            pass
         except:
-            transaction.rollback()
             raise
-        finally:
-            transaction.set_autocommit(app_autocommit_flag)
 
         return response
 
@@ -276,19 +282,17 @@ def _database_transaction_batch(func):
 def _database_transaction(func):
     @functools.wraps(func)
     def inner(ctx, resource, request, func=func):
-        app_autocommit_flag = transaction.get_autocommit()
-        transaction.set_autocommit(False)
         try:
-            response = func(ctx, resource, request)
-            if 200 <= response.status_code < 300:
-                transaction.commit()
-            else:
-                transaction.rollback()
+            with transaction.atomic():
+                response = func(ctx, resource, request)
+                if not 200 <= response.status_code < 300:
+                    # force a rollback
+                    raise _RequestError
+        except _RequestError:
+            # Allow the response to be returned
+            pass
         except:
-            transaction.rollback()
             raise
-        finally:
-            transaction.set_autocommit(app_autocommit_flag)
 
         return response
 

--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -264,10 +264,9 @@ def _database_transaction_batch(func):
                     # force a rollback
                     raise _RequestError
         except _RequestError:
-            # Allow the response to be returned.
-            pass
-        except:
-            raise
+            # The transaction should be rolled back
+            # return the response
+            return response
 
         return response
 
@@ -289,10 +288,9 @@ def _database_transaction(func):
                     # force a rollback
                     raise _RequestError
         except _RequestError:
-            # Allow the response to be returned
-            pass
-        except:
-            raise
+            # The transaction should be rolled back
+            # return the response
+            return response
 
         return response
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = '0.1.6.2'
+version = '0.1.6.3'
 
 setup(
     name='savory-pie',


### PR DESCRIPTION
In a previous PR we updated the commands that savory pie uses commit/rollback transactions after serving a response.  As it turns out, many of the transaction management commands are disabled when code is being executed in an atomic block.  For instance, when and savory-pie endpoint is invoked as part of a Django test that inherits from `TransactionTestCase`, `transaction.set_autocommit` will raise a `TransactionManagmentError`.

In this PR I have updated the `_db_transaction` decorator to run the wrapped function in an atomic block.  If the response returns an error, I raise a subclass of `DatabaseError` which will cause Django to rollback the transaction.  This should be roughly equivalent to the previous behavior.